### PR TITLE
Masonite 5 compatibility (milestone v0.1)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -22,7 +22,7 @@ jobs:
         run: |
           make coverage
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -32,11 +32,11 @@ jobs:
     name: Lint
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
-      - name: Intall Flake8
+          python-version: "3.12"
+      - name: Install Flake8
         run: |
           pip install flake8
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/actions/workflow/status/usecollapsar/collapsar/pythonapp.yml?branch=develop">
   <img src="https://codecov.io/gh/usecollapsar/collapsar/branch/develop/graph/badge.svg?token="/>
   <img alt="PyPI" src="https://img.shields.io/pypi/v/collapsar">
-  <img src="https://img.shields.io/badge/python-3.6+-blue.svg" alt="Python Version">
+  <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python Version">
   <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/usecollapsar/collapsar?include_prereleases">
   <img alt="License" src="https://img.shields.io/github/license/usecollapsar/collapsar">
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
@@ -31,7 +31,14 @@ Collapsar is a package that will let you save time creating a dashboard for your
 
 See the [official documentation](https://collapsar.aguad.dev) to learn how to use Collapsar.
 
+## Requirements
+
+- Python 3.10 – 3.13
+- Masonite 5 (`masonite-framework>=5`) — Collapsar ≤ 0.0.14 supported Masonite 4 only
+
 ## Installation
+
+Inside a [Masonite 5 application](https://docs.masonite.dev/getting-started/installation/):
 
 ```bash
 pip install collapsar
@@ -55,13 +62,20 @@ PROVIDERS = [
 ]
 ```
 
-Create a new resource using
+Create a new resource for one of your models:
 
-```python
-python craft resource MyModel
+```bash
+python craft resource User
 ```
 
-And see your panel on https://localhost/collapsar
+This generates `app/collapsar/resources/User.py`, which Collapsar discovers automatically on boot. Make sure you have at least one user to log in with (you can create one with `python craft collapsar:user`), then start the server and open the panel:
+
+```bash
+python craft serve
+```
+
+- Admin panel: `http://localhost:8000/collapsar` (redirects to `/collapsar/auth/login` until you sign in)
+- JSON API used by the panel: `http://localhost:8000/collapsar-api/...` (auth protected)
 
 ## Contributing
 

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ ci: ## [CI] Run package tests and lint
 	make test
 	make lint
 lint: ## Run code linting
-	python -m flake8 src/collapsar --ignore=E501,F401,E203,E128,E402,E731,F821,E712,W503,F811
+	python -m flake8 src/collapsar --ignore=E501,F401,E203,E128,E402,E731,E712,W503
 format: ## Format code with Black
 	black src/collapsar
 coverage: ## Run package tests and upload coverage reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-masonite>=4,<5
-masonite-orm>=2,<3
+masonite-framework>=5,<6
+masonite-framework-orm>=3,<4
 requests>=2.31
 python-slugify>=8

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,10 @@ setup(
         "Operating System :: OS Independent",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Internet :: WWW/HTTP :: WSGI",
@@ -70,10 +70,10 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
+    python_requires=">=3.10",
     install_requires=[
-        "masonite>=4.0,<5.0",
-        "masonite>=4,<5",
-        "masonite-orm>=2,<3",
+        "masonite-framework>=5,<6",
+        "masonite-framework-orm>=3,<4",
         "attrs>=23",
         "requests>=2.31",
         "python-slugify>=8",

--- a/src/collapsar/Boolean.py
+++ b/src/collapsar/Boolean.py
@@ -20,14 +20,12 @@ class Boolean(Field):
 
         super().__init__(name, attribute, resolve_callback)
 
-
     def fill(self, request, model: Model):
         setattr(
             model,
             self.attribute,
             1 if request.input(self.attribute) == "true" else 0,
         )
-
 
     def json_serialize(self):
         """

--- a/src/collapsar/commands/UserAddCommand.py
+++ b/src/collapsar/commands/UserAddCommand.py
@@ -4,6 +4,7 @@ from getpass import getpass
 from masonite.commands.Command import Command
 from masonite.facades.Hash import Hash
 
+
 class UserAddCommand(Command):
     """
     Installs collapsar

--- a/tests/integrations/config/factories.py
+++ b/tests/integrations/config/factories.py
@@ -1,5 +1,5 @@
 # config/factories.py
-from masoniteorm import Factory
+from masoniteorm.factories import Factory
 from tests.integrations.app.models.Article import Article
 
 


### PR DESCRIPTION
Completes milestone **v0.1 - Masonite 5 Compatibility**.

## What's here

- **Deps**: `masonite-framework>=5,<6` + `masonite-framework-orm>=3,<4` (removes the duplicated masonite pin), `python_requires>=3.10`, classifiers 3.10–3.13 — closes #7
- **Tests**: suite passes on masonite-framework 5.2.0 / ORM 3.0.2. The only code change needed was the ORM 3 factory import (`from masoniteorm.factories import Factory`). Also tightened flake8 (dropped `F821`/`F811` ignores — zero violations existed) and fixed the 3 blank-line violations that were already failing lint — closes #8
- **CI**: matrix 3.10–3.13, setup-python@v5, codecov-action@v4, lint on 3.12 — closes #9
- **Smoke test on a clean Masonite 5 app** (`masonite new` + wheel install): provider boots, migrations run, `craft resource User` scaffolds, `/collapsar` 302→login, login 200, assets 200, API auth-protected. README documents the verified flow — closes #10

## Found along the way (out of scope here)

1. **Masonite upstream bug**: `PackageProvider.root()` resolves the package root with a first-occurrence substring `find()` over `__file__` — booting crashes with `views() first argument must be a folder...` whenever the *project path* contains the package name (e.g. an app under `/tmp/collapsar-smoke` or an editable install from a repo dir named `collapsar`). Will be reported on masonitedev/masonite.
2. `dist/` (compiled frontend) is gitignored and only built at publish time — local wheels need `npm install && npx vite build` first; noted for the docs issue.

## Verification

```
python -m pytest tests   → 3 passed
make lint                → clean
smoke: login 200 / app.js 200 (2.0MB) / style.css 200 / api & dashboard 302 sin auth
```