### PR TITLE
chore: repoint repository references to the masonitedev org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ When contributing to this repository, **please first discuss the change you wish
 
 First you should configure your local environment to be able to make changes in this package.
 
-1. Fork the `https://github.com/usecollapsar/collapsar` repo.
+1. Fork the `https://github.com/masonitedev/collapsar` repo.
 2. Clone that repo into your computer: `git clone http://github.com/your-username/collapsar.git`.
 3. Checkout the current release branch \(example: `master`\).
 4. Run `git pull origin master` to get the current release version.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
   <a href="https://collapsar.aguad.dev">
     <img alt="Collapsar" src="https://img.shields.io/static/v1?label=Masonite&message=package&labelColor=grey&color=blue&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAIRlWElmTU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAA6gAwAEAAAAAQAAAA4AAAAATspU+QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAnxJREFUKBVNUl1IVEEUPjPObdd1VdxWM0rMIl3bzbVWLSofVm3th0AhMakHHyqRiNSHEAq5b2HSVvoQRUiEECQUQkkPbRslRGigG8auoon2oPSjpev+3PWeZq7eaC5nDt93vplz5txDQJYpNxX4st4JFiwj9aCqmswUFQNS/A2YskrZJPYefkECC2GhQwAqvLYybwXrwBvq8HSNOXRO92+aH7nW8vc/wS2Z9TqneYt2KHjlf9Iv+43wFJMExzO0YE5OKe60N+AOW6OmE+WJTBrg23jjzWxMBauOlfyycsV24F+cH+zAXYUOGl+DaiDxfl245/W9OnVrSY+O2eqPkyz4sVvHoKp9gOihf5KoAVv3hkQgbj/ihG9fI3RixKcUVx7lJVaEc0vnyf2FFll+ny80ZHZiGhIKowWJBCEAKr+FSuNDLt+lxybSF51lo74arqs113dOZqwsptxNs5bwi7Q3q8npSC2AWmvjTncZf1l61e5DEizNn5mtufpsqk5+CZTuq00sP1wkNPv8jeEikVVlJso+GEwRtNs3QeBt2YP2V2ZI3Tx0e+7T89zK5tNASOLEytJAryGtkLc2PcBM5byyUWYkMQpMioYcDcchC6xN220Iv36Ot8pV0454RHLEwmmD7UWfIdX0zq3GjMPG5NKBtv5qiPEPekK2U51j1451BZoc3i+1ohSQ/UzzG5uYFFn2mwVUnO4O3JblXA91T51l3pB3QweDl7sNXMyEjbguSjrPcQNmwDkNc8CbCvDd0+xCC7RFi9wFulD3mJeXqxQevB4prrqgc0TmQ85NG/K43e2UwnMVAJIEBNfWRYR3HfnvivrIzMyo4Hgy+hfscvLo53jItAAAAABJRU5ErkJggg==">
   </a>
-  <img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/actions/workflow/status/usecollapsar/collapsar/pythonapp.yml?branch=develop">
-  <img src="https://codecov.io/gh/usecollapsar/collapsar/branch/develop/graph/badge.svg?token="/>
+  <img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/actions/workflow/status/masonitedev/collapsar/pythonapp.yml?branch=develop">
+  <img src="https://codecov.io/gh/masonitedev/collapsar/branch/develop/graph/badge.svg?token="/>
   <img alt="PyPI" src="https://img.shields.io/pypi/v/collapsar">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python Version">
-  <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/usecollapsar/collapsar?include_prereleases">
-  <img alt="License" src="https://img.shields.io/github/license/usecollapsar/collapsar">
+  <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/masonitedev/collapsar?include_prereleases">
+  <img alt="License" src="https://img.shields.io/github/license/masonitedev/collapsar">
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     # The project's main homepage.
-    url="https://github.com/usecollapsar/collapsar",
+    url="https://github.com/masonitedev/collapsar",
     # Author details
     author="Eduardo Aguad",
     author_email="eduardo@aguad.dev",


### PR DESCRIPTION
Following the repository's move to the `masonitedev` organization, this repoints references that pointed at the old location.

## Changed
- `README.md` — workflow/codecov/release/license badges now point to `masonitedev/collapsar`.
- `setup.py` — project `url` → `https://github.com/masonitedev/collapsar`.
- `CONTRIBUTING.md` — fork URL → `masonitedev/collapsar`.

## Intentionally left as-is
- `sonar-project.properties` `sonar.projectKey` (`usecollapsar_collapsar_…`) — this is a SonarCloud project identifier, not a GitHub URL. Renaming it blindly would orphan the SonarCloud project/history; it needs to be reconfigured in SonarCloud for the new org (manual follow-up).
- `collapsar.aguad.dev` docs links — the documentation domain, not an org reference.
- PyPI package name stays `collapsar`.

The old `usecollapsar/collapsar` URL redirects to this repo automatically after the transfer.